### PR TITLE
Remove RECORD

### DIFF
--- a/python/pip_install/private/generate_whl_library_build_bazel.bzl
+++ b/python/pip_install/private/generate_whl_library_build_bazel.bzl
@@ -142,10 +142,6 @@ def generate_whl_library_build_bazel(
         "**/*.py",
         "**/*.pyc",
         "**/*.pyc.*",  # During pyc creation, temp files named *.pyc.NNNN are created
-        # RECORD is known to contain sha256 checksums of files which might include the checksums
-        # of generated files produced when wheels are installed. The file is ignored to avoid
-        # Bazel caching issues.
-        "**/*.dist-info/RECORD",
     ]
     for item in data_exclude:
         if item not in _data_exclude:

--- a/python/pip_install/repositories.bzl
+++ b/python/pip_install/repositories.bzl
@@ -110,7 +110,6 @@ py_library(
         "**/*.pyc",
         "**/*.pyc.*",  # During pyc creation, temp files named *.pyc.NNN are created
         "**/* *",
-        "**/*.dist-info/RECORD",
         "BUILD",
         "WORKSPACE",
     ]),


### PR DESCRIPTION
Right now RECORD files are excluded from pip packages, but they are necessary for some of our internal tooling to work. This removes them for now, so that we can point internally at this fork. I'm investigating what it would require to make this configurable and PR that back upstream: as of now it looks like we'd have to change the interface for `pip_repository`. 

I'd like to merge this for now, and I'm going to timebox trying to get a PR going for the folks upstream to look at.  