### PR TITLE
Use pip_protobuf as runtime

### DIFF
--- a/python/private/proto/BUILD
+++ b/python/private/proto/BUILD
@@ -28,5 +28,5 @@ proto_lang_toolchain(
     name = "python_toolchain",
     command_line = "--python_out=%s",
     progress_message = "Generating Python proto_library %{label}",
-    runtime = "@com_google_protobuf//:protobuf_python",
+    runtime = "@pip_protobuf//:pkg",
 )


### PR DESCRIPTION
**Problem**
Currently rules_python injects the `@com_google_protobuf//:protobuf_python` as the protobuf runtime of proto-generated `py_proto_library` targets. This actually is inconvenient since protoc version may not match up with pip protobuf runtime.
Often pip protobuf needs to go ahead of the protoc version to use 3rdparty libraries etc.

**Solution**
This changes the `proto_lang_toolchain` definition since as far as I can tell rules_python doesn't expose the knob to customize this at build time unlike Java does with `--proto_toolchain_for_java`.
