### PR TITLE
[forward port] Use pip_protobuf as runtime

### DIFF
--- a/python/private/proto/BUILD.bazel
+++ b/python/private/proto/BUILD.bazel
@@ -39,7 +39,7 @@ proto_lang_toolchain(
     name = "python_toolchain",
     command_line = "--python_out=%s",
     progress_message = "Generating Python proto_library %{label}",
-    runtime = "@com_google_protobuf//:protobuf_python",
+    runtime = "@pip_protobuf//:pkg",
     # NOTE: This isn't *actually* public. It's an implicit dependency of py_proto_library,
     # so must be public so user usages of the rule can reference it.
     visibility = ["//visibility:public"],


### PR DESCRIPTION
This forward ports https://github.com/bazeltools/rules_python/pull/3 on top of main branch.

**Problem**
Currently rules_python injects the `@com_google_protobuf//:protobuf_python` as the protobuf runtime of proto-generated `py_proto_library` targets. This actually is inconvenient since protoc version may not match up with pip protobuf runtime.
Often pip protobuf needs to go ahead of the protoc version to use 3rdparty libraries etc.

**Solution**
This changes the `proto_lang_toolchain` definition since as far as I can tell rules_python doesn't expose the knob to customize this at build time unlike Java does with `--proto_toolchain_for_java`.